### PR TITLE
Added support to receive token from iframe host window

### DIFF
--- a/AzureFunctions.Client/app/components/app.component.ts
+++ b/AzureFunctions.Client/app/components/app.component.ts
@@ -72,6 +72,15 @@ export class AppComponent implements OnInit{
 
     ngOnInit() {
         this.initializing = true;
+        if (window.parent !== window) {
+            this._functionsService.initializeIframe(() => { this.initializeUser() });
+        }
+        else {
+            this.initializeUser();
+        }
+    }
+
+    private initializeUser(){
         this._functionsService.initializeUser()
             .subscribe(r => {
                 if (!r) {
@@ -100,7 +109,7 @@ export class AppComponent implements OnInit{
                                     });
                             }
                         });
-                    
+
                 } else {
                     this.initFunctions();
                 }

--- a/AzureFunctions.Client/app/services/ifunctions.service.ts
+++ b/AzureFunctions.Client/app/services/ifunctions.service.ts
@@ -10,6 +10,7 @@ import {Subscription} from '../models/subscription';
 import {HostSecrets} from '../models/host-secrets';
 
 export interface IFunctionsService {
+    initializeIframe(callback: () => void): void;
     initializeUser(): Observable<ScmInfo>;
     getFunctions(): Observable<FunctionInfo[]>;
     getFileContent(file: VfsObject): Observable<string>;

--- a/AzureFunctions.Client/app/services/mock-functions.service.ts
+++ b/AzureFunctions.Client/app/services/mock-functions.service.ts
@@ -18,6 +18,10 @@ export class MockFunctionsService implements IFunctionsService {
 
     constructor(private _http: Http) { }
 
+    initializeIframe(): Observable<ScmInfo> {
+        return null;
+    }
+
     initializeUser() {
         return this._http.get('mocks/scmInfo.json')
             .map<ScmInfo>(r => {

--- a/AzureFunctions/Code/UserSettings.cs
+++ b/AzureFunctions/Code/UserSettings.cs
@@ -20,7 +20,15 @@ namespace AzureFunctions.Code
         {
             get
             {
-                return this._currentRequest.Headers.GetValues(Constants.X_MS_OAUTH_TOKEN).FirstOrDefault();
+                var headerValues = this._currentRequest.Headers.GetValues(Constants.ClientTokenHeader);
+                var token = headerValues != null ? headerValues.FirstOrDefault() : null;
+                if (token == null)
+                {
+                    headerValues = this._currentRequest.Headers.GetValues(Constants.X_MS_OAUTH_TOKEN);
+                    token = headerValues != null ? headerValues.FirstOrDefault() : null;
+                }
+
+                return token;
             }
         }
     }

--- a/AzureFunctions/Common/Constants.cs
+++ b/AzureFunctions/Common/Constants.cs
@@ -11,6 +11,7 @@ namespace AzureFunctions.Common
         public const string CSMApiVersion = "2014-04-01";
         public const string CSMUrl = "https://management.azure.com";
         public const string X_MS_OAUTH_TOKEN = "X-MS-OAUTH-TOKEN";
+        public const string ClientTokenHeader = "client-token";
         public const string ApplicationJson = "application/json";
         public const string AzureStorageAppSettingsName = "AzureWebJobsStorage";
         public const string AzureStorageDashboardAppSettingsName = "AzureWebJobsDashboard";


### PR DESCRIPTION
If the app component detects that we're in an iframe, it will wire-up callbacks so that the host can speak to the iframe.  For now we're only passing in a simple bearer token, but we can expand on that as new functionality is required.